### PR TITLE
Integrate PriceEngine service

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@
 -ANTHROPIC_API_KEY=sk-ant-api03-...
 -SALESFORCE_USERNAME=...
 -SAP_REST_BASE_URL=https://51.91.130.136:50000/b1s/v1
+-PRICE_ENGINE_URL=https://price-engine.example.com/api
 -INSEE_API_KEY=... # Validation SIRET
 -EMAIL_VALIDATION_ENABLED=true
 -CACHE_ENABLED=true


### PR DESCRIPTION
## Summary
- add `PRICE_ENGINE_URL` config in README and MCP
- implement `call_price_engine` helper in `sap_mcp.py`
- use PriceEngine data when fetching product details
- prefer discounted unit price in workflow

## Testing
- `pip install -q httpx aiohttp requests python-dotenv fuzzywuzzy python-Levenshtein`
- `pytest -s` *(fails: async plugin missing and missing env variables)*

------
https://chatgpt.com/codex/tasks/task_e_6877a9fa756883288cd232e30b9b2147